### PR TITLE
make dependencies on menu and routing explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,16 @@
     "require": {
         "php": ">=5.3.9",
         "symfony/framework-bundle": "~2.3",
-        "symfony-cmf/core-bundle": "~1.1"
+        "symfony-cmf/core-bundle": "~1.1",
+        "symfony-cmf/menu-bundle": "~1.1",
+        "symfony-cmf/routing-bundle": "~1.2"
     },
     "require-dev": {
         "symfony-cmf/testing": "~1.2,>=1.2.6",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",
-        "symfony-cmf/menu-bundle": "~1.1",
-        "symfony-cmf/routing-bundle": "~1.2",
         "symfony/monolog-bundle": "~2.3"
     },
     "suggest": {
-        "symfony-cmf/menu-bundle": "Have editable menus for content",
-        "symfony-cmf/routing-bundle": "Have editable routes for content",
         "friendsofsymfony/rest-bundle": "Improved handling for different output formats",
         "doctrine/phpcr-odm": "To persist content with the PHP content repository",
         "doctrine/phpcr-bundle": "To integrate PHPCR-ODM with Symfony",


### PR DESCRIPTION
fix #126

i did not find any way to tell doctrine to skip building the proxy of a specific class (we could simply try to dynamically remove the metadata but i think its just not worth it). we do not need to adjust the documentation, you don't need to instantiate the menu or routing bundle if you do not use them.